### PR TITLE
Fix simplejson import

### DIFF
--- a/simple_autocomplete/views.py
+++ b/simple_autocomplete/views.py
@@ -1,4 +1,4 @@
-import simplejson
+from django.utils import simplejson    
 import pickle
 
 from django.http import HttpResponse


### PR DESCRIPTION
Newer python versions don't come with simplejson, as it's built in. Django comes with it, so importing it from django works.
